### PR TITLE
Fixes gkasdorf/memmy#39

### DIFF
--- a/components/ui/CommentItem.tsx
+++ b/components/ui/CommentItem.tsx
@@ -43,6 +43,7 @@ const CommentItem = ({comment, depth = 1}: CommentItemProps) => {
     if(comment.top.comment.id !== lastCommentId.current) {
         lastCommentId.current = comment.top.comment.id;
         setCollapsed(false);
+        setMyVote(comment.top.my_vote);
     }
 
     const onVote = async (value: -1 | 0 | 1) => {


### PR DESCRIPTION
When reusing a comment component update the vote state (upvoted, neutral, down-voted) from the API data.
Prevents having an 'old' state used for a component when it's reused.