### PR TITLE
Fix Instance URL in Post Screen

### DIFF
--- a/components/screens/post/PostScreen.tsx
+++ b/components/screens/post/PostScreen.tsx
@@ -69,7 +69,7 @@ function PostScreen({
     return <LoadingView />;
   }
 
-  const instanceBaseUrl = getBaseUrl(post.currentPost.creator.actor_id);
+  const instanceBaseUrl = getBaseUrl(post.currentPost.community.actor_id);
 
   const header = (
     <VStack flex={1} backgroundColor={theme.colors.app.fg}>
@@ -79,6 +79,8 @@ function PostScreen({
         <AvatarUsername
           username={post.currentPost?.creator.name}
           fullUsername={getUserFullName(post.currentPost?.creator)}
+          showInstance
+          instanceName={post.currentPost.creator.actor_id}
           avatar={post.currentPost?.creator.avatar}
         />
       </HStack>

--- a/components/screens/post/PostScreen.tsx
+++ b/components/screens/post/PostScreen.tsx
@@ -80,7 +80,7 @@ function PostScreen({
           username={post.currentPost?.creator.name}
           fullUsername={getUserFullName(post.currentPost?.creator)}
           showInstance
-          instanceName={post.currentPost.creator.actor_id}
+          creatorActorId={post.currentPost.creator.actor_id}
           avatar={post.currentPost?.creator.avatar}
         />
       </HStack>

--- a/components/ui/comments/CommentItem2.tsx
+++ b/components/ui/comments/CommentItem2.tsx
@@ -326,7 +326,7 @@ function CommentItem2({
                         fullUsername={getUserFullName(
                           nestedComment.comment.creator
                         )}
-                        instanceName={nestedComment.comment.creator.actor_id}
+                        creatorActorId={nestedComment.comment.creator.actor_id}
                         showInstance={showInstanceForUsernames}
                       >
                         <>

--- a/components/ui/common/AvatarUsername.tsx
+++ b/components/ui/common/AvatarUsername.tsx
@@ -9,7 +9,7 @@ interface AvatarUsernameProps {
   avatar: string;
   username: string;
   fullUsername: string;
-  instanceName?: string;
+  creatorActorId?: string;
   showInstance?: boolean;
   children?: JSX.Element;
 }
@@ -18,7 +18,7 @@ function AvatarUsername({
   avatar,
   username,
   fullUsername,
-  instanceName,
+  creatorActorId,
   showInstance,
   children,
 }: AvatarUsernameProps) {
@@ -38,7 +38,9 @@ function AvatarUsername({
       )}
       <VStack>
         <UserLink username={username} fullUsername={fullUsername} />
-        {showInstance && <Text fontSize="xs">{getBaseUrl(instanceName)}</Text>}
+        {showInstance && (
+          <Text fontSize="xs">{getBaseUrl(creatorActorId)}</Text>
+        )}
       </VStack>
       {children}
     </HStack>

--- a/components/ui/markdown/RenderMarkdown.tsx
+++ b/components/ui/markdown/RenderMarkdown.tsx
@@ -87,7 +87,7 @@ const RenderMarkdown = ({
       backgroundColor: theme.colors.app.bgTertiary,
       borderRadius: 5,
       borderLeftWidth: 3,
-      borderLeftColor: theme.colors.orange["500"],
+      borderLeftColor: theme.colors.app.accent,
       marginVertical: 10,
     },
     code_inline: {


### PR DESCRIPTION
We were using `creator.actor_id` instead of `community.actor_id` to display the instance name for a community.