### PR TITLE
feat: hide compact voting buttons setting

### DIFF
--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -239,45 +239,47 @@ function SettingsIndexScreen({
           />
         </Section>
 
-        <Section header="COMPACT" roundedCorners hideSurroundingSeparators>
-          <CCell
-            cellStyle="RightDetail"
-            title="Thumbnails Position"
-            detail={settings.compactThumbnailPosition}
-            accessory="DisclosureIndicator"
-            onPress={() => {
-              const options = ["Left", "Right", "Cancel"];
-              const cancelButtonIndex = 2;
+        {settings.compactView && (
+          <Section header="COMPACT" roundedCorners hideSurroundingSeparators>
+            <CCell
+              cellStyle="RightDetail"
+              title="Thumbnails Position"
+              detail={settings.compactThumbnailPosition}
+              accessory="DisclosureIndicator"
+              onPress={() => {
+                const options = ["Left", "Right", "Cancel"];
+                const cancelButtonIndex = 2;
 
-              showActionSheetWithOptions(
-                {
-                  options,
-                  cancelButtonIndex,
-                },
-                (index: number) => {
-                  if (index === cancelButtonIndex) return;
+                showActionSheetWithOptions(
+                  {
+                    options,
+                    cancelButtonIndex,
+                  },
+                  (index: number) => {
+                    if (index === cancelButtonIndex) return;
 
-                  dispatch(
-                    setSetting({ compactThumbnailPosition: options[index] })
-                  );
-                }
-              );
-            }}
-          />
-          <CCell
-            cellStyle="RightDetail"
-            title="Show Voting Buttons"
-            backgroundColor={theme.colors.app.fg}
-            titleTextColor={theme.colors.app.textPrimary}
-            rightDetailColor={theme.colors.app.textSecondary}
-            cellAccessoryView={
-              <Switch
-                value={settings.compactShowVotingButtons}
-                onValueChange={(v) => onChange("compactShowVotingButtons", v)}
-              />
-            }
-          />
-        </Section>
+                    dispatch(
+                      setSetting({ compactThumbnailPosition: options[index] })
+                    );
+                  }
+                );
+              }}
+            />
+            <CCell
+              cellStyle="RightDetail"
+              title="Show Voting Buttons"
+              backgroundColor={theme.colors.app.fg}
+              titleTextColor={theme.colors.app.textPrimary}
+              rightDetailColor={theme.colors.app.textSecondary}
+              cellAccessoryView={
+                <Switch
+                  value={settings.compactShowVotingButtons}
+                  onValueChange={(v) => onChange("compactShowVotingButtons", v)}
+                />
+              }
+            />
+          </Section>
+        )}
 
         <Section header="ABOUT" roundedCorners hideSurroundingSeparators>
           <CCell

--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -237,10 +237,12 @@ function SettingsIndexScreen({
               />
             }
           />
+        </Section>
 
+        <Section header="COMPACT" roundedCorners hideSurroundingSeparators>
           <CCell
             cellStyle="RightDetail"
-            title="Compact Thumbnails Position"
+            title="Thumbnails Position"
             detail={settings.compactThumbnailPosition}
             accessory="DisclosureIndicator"
             onPress={() => {
@@ -261,6 +263,19 @@ function SettingsIndexScreen({
                 }
               );
             }}
+          />
+          <CCell
+            cellStyle="RightDetail"
+            title="Show Voting Buttons"
+            backgroundColor={theme.colors.app.fg}
+            titleTextColor={theme.colors.app.textPrimary}
+            rightDetailColor={theme.colors.app.textSecondary}
+            cellAccessoryView={
+              <Switch
+                value={settings.compactShowVotingButtons}
+                onValueChange={(v) => onChange("compactShowVotingButtons", v)}
+              />
+            }
           />
         </Section>
 

--- a/components/ui/Feed/CompactFeedItem/CompactFeedItem.tsx
+++ b/components/ui/Feed/CompactFeedItem/CompactFeedItem.tsx
@@ -23,7 +23,8 @@ import CompactFeedItemFooter from "./CompactFeedItemFooter";
 import { selectSettings } from "../../../../slices/settings/settingsSlice";
 
 function CompactFeedItem({ post }: { post: PostView }) {
-  const { compactThumbnailPosition } = useAppSelector(selectSettings);
+  const { compactThumbnailPosition, compactShowVotingButtons } =
+    useAppSelector(selectSettings);
   const [imageViewOpen, setImageViewOpen] = useState(false);
 
   const feedItem = useFeedItem(post);
@@ -128,10 +129,12 @@ function CompactFeedItem({ post }: { post: PostView }) {
                   </VStack>
                 )}
 
-                <CompactFeedItemVote
-                  myVote={post.my_vote as ILemmyVote}
-                  post={post}
-                />
+                {compactShowVotingButtons && (
+                  <CompactFeedItemVote
+                    myVote={post.my_vote as ILemmyVote}
+                    post={post}
+                  />
+                )}
               </HStack>
             </Pressable>
           </Animated.View>

--- a/slices/settings/settingsSlice.ts
+++ b/slices/settings/settingsSlice.ts
@@ -17,6 +17,7 @@ export interface SettingsState {
   theme: ThemeOptions;
   pushEnabled: string;
   compactThumbnailPosition: "Left" | "Right";
+  compactShowVotingButtons: boolean;
 }
 
 const initialState: SettingsState = {
@@ -30,6 +31,7 @@ const initialState: SettingsState = {
   hideNsfw: false,
   compactView: false,
   compactThumbnailPosition: "Left",
+  compactShowVotingButtons: true,
   theme: "Brown",
   pushEnabled: "[]",
 };


### PR DESCRIPTION
Option for hiding voting buttons in compact view, also creates a section under settings for compact specific settings

<img src="https://github.com/gkasdorf/memmy/assets/2129171/0f3e5025-95bc-4f41-b045-5185a6b1fdc3" width="300" />

<img src="https://github.com/gkasdorf/memmy/assets/2129171/838e28b7-fadc-424d-8554-d4a1f3d4dd3c" width="300" />

