### PR TITLE
fix: community icon fallback to planet icon and subscribed icon fill

### DIFF
--- a/components/screens/feeds/CommunityFeedScreen.tsx
+++ b/components/screens/feeds/CommunityFeedScreen.tsx
@@ -5,8 +5,8 @@ import FastImage from "react-native-fast-image";
 import {
   IconEye,
   IconHeart,
-  IconHeartFilled,
   IconInfoCircle,
+  IconPlanet,
   IconPlus,
   IconUserHeart,
 } from "tabler-icons-react-native";
@@ -62,16 +62,21 @@ function FeedsCommunityScreen({
     return (
       <VStack pt={10} pb={5} px={5}>
         <HStack alignItems="center" space={5}>
-          <FastImage
-            source={{
-              uri: communityFeed.feed.community.community.icon,
-            }}
-            style={{
-              height: 96,
-              width: 96,
-              borderRadius: 100,
-            }}
-          />
+          {communityFeed.feed.community.community.icon ? (
+            <FastImage
+              source={{
+                uri: communityFeed.feed.community.community.icon,
+              }}
+              style={{
+                height: 96,
+                width: 96,
+                borderRadius: 100,
+              }}
+            />
+          ) : (
+            <IconPlanet color={theme.colors.app.textSecondary} size={64} />
+          )}
+
           <VStack alignContent="center">
             <HStack space={2}>
               <HStack space={1}>
@@ -102,7 +107,8 @@ function FeedsCommunityScreen({
           <HStack justifyContent="space-between" alignItems="center" space={3}>
             <CustomButton
               onPress={communityFeed.onSubscribePress}
-              icon={communityFeed.feed.subscribed ? IconHeartFilled : IconHeart}
+              icon={IconHeart}
+              iconFill={communityFeed.feed.subscribed}
               text={communityFeed.feed.subscribed ? "Subscribed" : "Subscribe"}
             />
             <CustomButton

--- a/components/ui/buttons/CustomButton.tsx
+++ b/components/ui/buttons/CustomButton.tsx
@@ -6,6 +6,7 @@ function CustomButton({
   onPress,
   text,
   icon,
+  iconFill = false,
   selectable = false,
   size = "md",
   badge,
@@ -13,6 +14,7 @@ function CustomButton({
   onPress: () => void;
   text: string;
   icon?: TablerIcon;
+  iconFill?: boolean;
   selectable?: boolean;
   size?: "md" | "sm";
   badge?: string;
@@ -57,6 +59,7 @@ function CustomButton({
           <IconComponent
             size={size === "md" ? 24 : 20}
             color={theme.colors.app.accent}
+            fill={iconFill ? theme.colors.app.accent : undefined}
           />
         )}
         <Text fontSize={size} color={theme.colors.app.textPrimary}>


### PR DESCRIPTION
* Community icon fallback to icon planet
* Made it possible to fill icons, making subscribe icon look better in different themes

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/gkasdorf/memmy/assets/2129171/daba6e4a-58f6-4ae9-94cd-c27d9faa80b8" width="300" />   | <img src="https://github.com/gkasdorf/memmy/assets/2129171/b9979f5b-913d-489b-9870-ca1eee43002c" width="300" /> |








