### PR TITLE
add calendar week icon for sort

### DIFF
--- a/components/ui/Feed/FeedView.tsx
+++ b/components/ui/Feed/FeedView.tsx
@@ -30,6 +30,7 @@ import { selectSettings } from "../../../slices/settings/settingsSlice";
 import NoPostsView from "./NoPostsView";
 import { ExtensionType, getLinkInfo } from "../../../helpers/LinkHelper";
 import HeaderIconButton from "../buttons/HeaderIconButton";
+import { IconCalendarWeek } from "../customIcons";
 
 interface FeedViewProps {
   feed: UseFeed;
@@ -39,7 +40,7 @@ interface FeedViewProps {
 
 const SortIconType = {
   TopDay: <IconCalendar />,
-  TopWeek: <IconCalendar />,
+  TopWeek: <IconCalendarWeek />,
   Hot: <IconFlame />,
   Active: <IconBolt />,
   New: <IconClockHour4 />,

--- a/components/ui/customIcons/IconCalendarWeek.tsx
+++ b/components/ui/customIcons/IconCalendarWeek.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+import { type TablerIconsProps } from "tabler-icons-react-native";
+
+// eslint-disable-next-line import/prefer-default-export
+export function IconCalendarWeek({
+  size = 24,
+  color = "#1f2937", // Defaut tabler color
+  stroke = 2,
+}: TablerIconsProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      strokeWidth={stroke}
+      stroke={color || "currentColor"}
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <Path d="M4 7a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12z" />
+      <Path d="M16 3v4" />
+      <Path d="M8 3v4" />
+      <Path d="M4 11h16" />
+      <Path d="M10.5 14h3l-2 4" />
+    </Svg>
+  );
+}

--- a/components/ui/customIcons/index.ts
+++ b/components/ui/customIcons/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { IconCalendarWeek } from "./IconCalendarWeek";


### PR DESCRIPTION
Since both top day and top week icons where the same and no icon counterpart for week existed I created one. 

Works the same as the other icons.

<img height="200" alt="Screenshot 2023-06-28 at 22 25 21" src="https://github.com/gkasdorf/memmy/assets/2129171/22167096-0b98-41ac-91eb-0bbdaab90700" />

<img height="200" alt="Screenshot 2023-06-28 at 22 25 21" src="https://github.com/gkasdorf/memmy/assets/2129171/5e94e3a3-c2ce-4774-86bf-d84c89843c84" />
