### PR TITLE
show pin icon on featured posts

### DIFF
--- a/components/ui/Feed/CompactFeedItem/CompactFeedItemFooter.tsx
+++ b/components/ui/Feed/CompactFeedItem/CompactFeedItemFooter.tsx
@@ -1,7 +1,7 @@
 import { PostView } from "lemmy-js-client";
 import { HStack, Text, useTheme } from "native-base";
 import React, { useRef } from "react";
-import { IconMessage } from "tabler-icons-react-native";
+import { IconMessage, IconPin } from "tabler-icons-react-native";
 import { timeFromNowShort } from "../../../../helpers/TimeHelper";
 import { ILemmyVote } from "../../../../lemmy/types/ILemmyVote";
 import CommunityLink from "../../CommunityLink";
@@ -20,6 +20,13 @@ function CompactFeedItemFooter({ post }: CompactFeedItemFooterProps) {
   return (
     <>
       <HStack alignItems="center" space={2}>
+        {(post.post.featured_local || post.post.featured_community) && (
+          <IconPin
+            size={16}
+            color={colors.app.accent}
+            fill={colors.app.accent}
+          />
+        )}
         <AvatarUsername creator={post.creator} showAvatar={false} />
         <Text color={colors.app.textSecondary}>•</Text>
         <Text color={colors.app.textSecondary}>

--- a/components/ui/Feed/FeedItem.tsx
+++ b/components/ui/Feed/FeedItem.tsx
@@ -13,6 +13,7 @@ import {
   IconArrowUp,
   IconClockHour5,
   IconMessage,
+  IconPin,
 } from "tabler-icons-react-native";
 import { timeFromNowShort } from "../../../helpers/TimeHelper";
 import { setResponseTo } from "../../../slices/newComment/newCommentSlice";
@@ -111,7 +112,19 @@ function FeedItem({ post, setPosts, recycled }: FeedItemProps) {
                 justifyContent="space-between"
                 alignItems="center"
               >
-                <AvatarUsername creator={post.creator} />
+                <HStack>
+                  <AvatarUsername creator={post.creator} />
+                  {(post.post.featured_local ||
+                    post.post.featured_community) && (
+                    <HStack mx="2" alignItems="center">
+                      <IconPin
+                        size={16}
+                        color={theme.colors.app.accent}
+                        fill={theme.colors.app.accent}
+                      />
+                    </HStack>
+                  )}
+                </HStack>
 
                 <HStack alignItems="center" space={1}>
                   <IconClockHour5


### PR DESCRIPTION
Added pin icon to indicate that post is sticket/pinned/featured. 

Not sure if we would want to differentiate between `featured_local` and `featured_community`. 
This PR shows them the same.

<table>
</tr>
<td>Compact</td>
<td>Expanded</td>
<tr>
<tr>
<td>
<img width="300" src="https://github.com/gkasdorf/memmy/assets/2129171/2aed1a23-6162-4872-96b4-be6029a0d423" />
</td>
<td>
<img width="300" src="https://github.com/gkasdorf/memmy/assets/2129171/02064260-b983-4c7f-9368-90fbf1d6db71" />
</td>


</tr>
</table>
