### PR TITLE
fix: thumnail position setting dark mode

### DIFF
--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -314,6 +314,7 @@ function SettingsIndexScreen({
                   {
                     options,
                     cancelButtonIndex,
+                    userInterfaceStyle: theme.config.initialColorMode,
                   },
                   (index: number) => {
                     if (index === cancelButtonIndex) return;


### PR DESCRIPTION
Thumbnail position setting showActionSheetWithOptions gets light mode when dark mode is active.