### PR TITLE
feat: improve header button and feed filter

### DIFF
--- a/components/ui/Feed/FeedOverflowButton.tsx
+++ b/components/ui/Feed/FeedOverflowButton.tsx
@@ -101,7 +101,9 @@ export function MainFeedOverflowButton({
     const cancelButtonIndex = overflowOptions.main.length - 1;
     showActionSheetWithOptions(
       {
-        options: overflowOptions.main,
+        options: overflowOptions.main.map((option) =>
+          option === feed.listingType ? `${option} (current)` : option
+        ),
         cancelButtonIndex,
         userInterfaceStyle: theme.config.initialColorMode,
       },

--- a/components/ui/Feed/FeedSortButton.tsx
+++ b/components/ui/Feed/FeedSortButton.tsx
@@ -38,7 +38,12 @@ function FeedSortButton({ feed, onSortUpdate }: Props) {
 
     showActionSheetWithOptions(
       {
-        options: [...sortOptions.map(([, display]) => display), "Cancel"],
+        options: [
+          ...sortOptions.map(([key, display]) =>
+            key === feed.sort ? `${display} (current)` : display
+          ),
+          "Cancel",
+        ],
         cancelButtonIndex,
         userInterfaceStyle: theme.config.initialColorMode,
       },

--- a/components/ui/buttons/HeaderIconButton.tsx
+++ b/components/ui/buttons/HeaderIconButton.tsx
@@ -14,7 +14,15 @@ function HeaderIconButton({ icon, onPress }: CIconButtonProps) {
   const newIconElement = React.cloneElement(iconElement, {
     color: theme.colors.app.accent,
   });
-  return <Pressable onPress={onPress}>{newIconElement}</Pressable>;
+  const newPressedIconElement = React.cloneElement(iconElement, {
+    color: theme.colors.app.accentHighlight,
+  });
+
+  return (
+    <Pressable onPress={onPress}>
+      {({ isPressed }) => (isPressed ? newPressedIconElement : newIconElement)}
+    </Pressable>
+  );
 }
 
 export default HeaderIconButton;


### PR DESCRIPTION
Sorry if I didn't create an issue first, not sure if you would prefer me to do that. I can create one if so, or I can close this if it's not on the roadmap, or if I was stepping on another devs toes.

I noticed that actively pressing the header buttons doesn't highlight them. When a user presses and holds the button, it may be unclear which one they are pressing. Adding the highlight color can help aid that.

This PR also adds `(current)` next to the currently selected feed filter action sheet, which was a requested feature in discord.

**Hot is actively being pressed in this screenshot**
![Screenshot 2023-06-30 at 10 28 13 PM](https://github.com/gkasdorf/memmy/assets/50721527/65d504b1-484d-4f06-bb91-22250d04b8b5)

**Currently selected filter**
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-06-30 at 22 38 00](https://github.com/gkasdorf/memmy/assets/50721527/a7360be5-1e7f-4717-a996-83a704d2a3a9)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-06-30 at 22 38 05](https://github.com/gkasdorf/memmy/assets/50721527/887e9258-fb74-4e53-bf28-5756e4a7cab9)

**Currently selected filter inside a community**
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-06-30 at 22 49 40](https://github.com/gkasdorf/memmy/assets/50721527/d1a8a3ef-5f2c-45a9-90e8-efd7e3451d47)

