### PR TITLE
Fix default sort option display

### DIFF
--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -39,6 +39,11 @@ function SettingsIndexScreen({
     return sortOptions[index][1];
   };
 
+  const getDefaultSortFromText = (sortType: string): SortType => {
+    const index = sortOptions.map((x: SortOption) => x[1]).indexOf(sortType);
+    return sortOptions[index][0];
+  };
+
   const onCacheClear = async () => {
     await FastImage.clearDiskCache();
     Alert.alert("Success", "Cache has been cleared.");
@@ -218,18 +223,7 @@ function SettingsIndexScreen({
                 (index: number) => {
                   if (index === cancelButtonIndex) return;
 
-                  let selection;
-
-                  if (index === 0) {
-                    selection = "TopDay";
-                  } else if (index === 1) {
-                    selection = "TopWeek";
-                  } else if (index === 5) {
-                    selection = "MostComments";
-                  } else {
-                    selection = options[index];
-                  }
-
+                  const selection = getDefaultSortFromText(options[index]);
                   dispatch(setSetting({ defaultSort: selection }));
                 }
               );

--- a/components/screens/settings/SettingsIndexScreen.tsx
+++ b/components/screens/settings/SettingsIndexScreen.tsx
@@ -8,6 +8,7 @@ import { Alert, LayoutAnimation, StyleSheet, Switch } from "react-native";
 import { getBuildNumber, getVersion } from "react-native-device-info";
 import FastImage from "react-native-fast-image";
 import { Section, TableView } from "react-native-tableview-simple";
+import { SortType } from "lemmy-js-client";
 import { deleteLog, sendLog } from "../../../helpers/LogHelper";
 import { selectAccounts } from "../../../slices/accounts/accountsSlice";
 import { setSetting } from "../../../slices/settings/settingsActions";
@@ -15,6 +16,7 @@ import { selectSettings } from "../../../slices/settings/settingsSlice";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { HapticOptionsArr } from "../../../types/haptics/hapticOptions";
 import CCell from "../../ui/table/CCell";
+import { sortOptions, SortOption } from "../../../types/FeedSortOptions";
 
 function SettingsIndexScreen({
   navigation,
@@ -30,6 +32,11 @@ function SettingsIndexScreen({
 
   const onChange = (key: string, value: any) => {
     dispatch(setSetting({ [key]: value }));
+  };
+
+  const getDefaultSortText = (sortType: SortType): string => {
+    const index = sortOptions.map((x: SortOption) => x[0]).indexOf(sortType);
+    return sortOptions[index][1];
   };
 
   const onCacheClear = async () => {
@@ -185,7 +192,7 @@ function SettingsIndexScreen({
           <CCell
             cellStyle="RightDetail"
             title="Default Sort"
-            detail={settings.defaultSort}
+            detail={getDefaultSortText(settings.defaultSort)}
             backgroundColor={theme.colors.app.fg}
             titleTextColor={theme.colors.app.textPrimary}
             rightDetailColor={theme.colors.app.textSecondary}
@@ -217,7 +224,7 @@ function SettingsIndexScreen({
                     selection = "TopDay";
                   } else if (index === 1) {
                     selection = "TopWeek";
-                  } else if (index === 4) {
+                  } else if (index === 5) {
                     selection = "MostComments";
                   } else {
                     selection = options[index];

--- a/components/ui/Feed/FeedSortButton.tsx
+++ b/components/ui/Feed/FeedSortButton.tsx
@@ -12,17 +12,7 @@ import {
 import { UseFeed } from "../../hooks/feeds/useFeed";
 import HeaderIconButton from "../buttons/HeaderIconButton";
 import { IconCalendarWeek } from "../customIcons";
-
-type SortOption = [key: SortType, display: string];
-
-const sortOptions = [
-  ["TopDay", "Top Day"],
-  ["TopWeek", "Top Week"],
-  ["Hot", "Hot"],
-  ["Active", "Active"],
-  ["New", "New"],
-  ["MostComments", "Most Comments"],
-] satisfies SortOption[];
+import { sortOptions } from "../../../types/FeedSortOptions";
 
 interface Props {
   feed: UseFeed;

--- a/types/FeedSortOptions.ts
+++ b/types/FeedSortOptions.ts
@@ -1,0 +1,12 @@
+import { SortType } from "lemmy-js-client";
+
+export type SortOption = [key: SortType, display: string];
+
+export const sortOptions = [
+  ["TopDay", "Top Day"],
+  ["TopWeek", "Top Week"],
+  ["Hot", "Hot"],
+  ["Active", "Active"],
+  ["New", "New"],
+  ["MostComments", "Most Comments"],
+] satisfies SortOption[];


### PR DESCRIPTION
This PR fixes #289. As discussed there, this also refactors `sortOptions` to `types/` from `FeedSortButton`.